### PR TITLE
Updated ComExample02_Flow

### DIFF
--- a/ComExample02_Flow/ComExample02_Flow.pde
+++ b/ComExample02_Flow/ComExample02_Flow.pde
@@ -5,6 +5,8 @@
 import processing.opengl.*; // opengl
 import SimpleOpenNI.*; // kinect
 import blobDetection.*; // blobs
+//importing java utility used in PolygonBlob
+import java.util.Collections.*;
 
 // this is a regular java import so we can use and extend the polygon class (see PolygonBlob)
 import java.awt.Polygon;
@@ -43,6 +45,8 @@ void setup() {
   size(1280, 720, OPENGL);
   // initialize SimpleOpenNI object
   context = new SimpleOpenNI(this);
+    // mirror the image to be more intuitive
+    context.setMirror(true);
   if (!context.enableDepth() || !context.enableUser()) { 
     // if context.enableScene() returns false
     // then the Kinect is not working correctly
@@ -50,8 +54,6 @@ void setup() {
     println("Kinect not connected!"); 
     exit();
   } else {
-    // mirror the image to be more intuitive
-    context.setMirror(true);
     // calculate the reScale value
     // currently it's rescaled to fill the complete width (cuts of top-bottom)
     // it's also possible to fill the complete height (leaves empty sides)
@@ -60,7 +62,7 @@ void setup() {
     blobs = createImage(kinectWidth/3, kinectHeight/3, RGB);
     // initialize blob detection object to the blob image dimensions
     theBlobDetection = new BlobDetection(blobs.width, blobs.height);
-    theBlobDetection.setThreshold(0.2);
+    theBlobDetection.setThreshold(0.7);
     setupFlowfield();
   }
 }

--- a/README.textile
+++ b/README.textile
@@ -12,7 +12,5 @@ http://forum.processing.org/two/discussion/2625/can-kinect-physics-code-examples
 
 All are examples are based upon Amnon's zip at the root of the forum thread. Respect!
 
-They all build & run but 02 doesn't seem to run correctly.
+They all build & run.
 The 03 source was copied from Modqhx post in the forum thread so credit to him for getting it running!
-
-This repo will hopefuly save someone else some time if they're tryin to follow the article. Please fork at will.


### PR DESCRIPTION
Got Amnon Owed's example 2 working in Processing 1.5.1 and 2.2.1 (unable in Processing 3).
-Changed blob detection threshold in line 65 from 0.2 to 0.7. Probably dependent on each user's conditions, but mine worked best set between 0.5 and 0.8. (Perhaps a change to v3ga library version affected blob detection?)
-Moved setting mirror before the conditional statement about kinect.
-Added line to import java utility used in PolygonBlob (doesn't seem to be essential, but read it somewhere as a recommendation).
